### PR TITLE
ci(build): build binary

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -15,56 +15,9 @@ on:
 #   cancel-in-progress: false
 
 jobs:
-  # build:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Upload artifact
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         path: ''
-
-  release:
-    name: Release
-    # needs: build
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Generate a changelog
-        uses: orhun/git-cliff-action@v4
-        id: git-cliff
-        with:
-          config: cliff.toml
-          args: -vv ${{ startsWith(github.ref, 'refs/tags/v') &&  '--latest' || '--unreleased' }} --strip header
-        env:
-          GITHUB_REPO: ${{ github.repository }}
-
-      - name: Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'nightly' }}
-          body: ${{ steps.git-cliff.outputs.content }}
-          prerelease: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
-          make_latest: ${{ startsWith(github.ref, 'refs/tags/v') }}
-
-  publish-pypi:
-    name: Publish to Pypi
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
-    environment:
-      name: pypi
-      url: https://pypi.org/p/cpn-cli
-    if: startsWith(github.ref, 'refs/tags/v')
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
@@ -85,8 +38,62 @@ jobs:
         run: just restore-env
 
       - name: Build
-        run: uv build
+        run: uv run build -t sdist -t wheel -t binary
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: dist/**
+
+  release:
+    name: Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v4
+
+      - name: Generate a changelog
+        uses: orhun/git-cliff-action@v4
+        id: git-cliff
+        with:
+          config: cliff.toml
+          args: -vv ${{ startsWith(github.ref, 'refs/tags/v') &&  '--latest' || '--unreleased' }} --strip header
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'nightly' }}
+          body: ${{ steps.git-cliff.outputs.content }}
+          prerelease: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
+          make_latest: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          files: dist/**
+
+  publish-pypi:
+    name: Publish to Pypi
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cpn-cli
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+
+      # TODO: Check if publish to pypi include binary or not? It's in ./dist/binary/
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,5 @@ cpn-cli = "cpn_cli:__main__.main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.hatch.build.targets.wheel]
-packages = ["src/cpn_cli"]
-
 [dependency-groups]
-dev = ["pre-commit>=4.0.1", "commitizen>=4.1.0"]
+dev = ["pre-commit>=4.0.1", "commitizen>=4.1.0", "hatch>=1.14.0"]


### PR DESCRIPTION
Waiting for hatch to support 3.13 binary build

https://github.com/pypa/hatch/blob/64031c1cf5d02d85203f68cb7a4fd5db2aa7a004/backend/src/hatchling/builders/binary.py#L12